### PR TITLE
Linting with eslint-plugin-react-hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@typescript-eslint/eslint-plugin": "^5.11.0",
         "@typescript-eslint/parser": "^5.11.0",
         "eslint": "^8.9.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
         "jest": "^27.5.0",
         "msw": "^0.36.8",
         "node-fetch": "^2.6.7",
@@ -6275,6 +6276,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-scope": {
@@ -20960,6 +20973,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "eslint": "^8.9.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "jest": "^27.5.0",
     "msw": "^0.36.8",
     "node-fetch": "^2.6.7",
@@ -94,9 +95,11 @@
     ],
     "extends": [
       "eslint:recommended",
-      "plugin:@typescript-eslint/recommended"
+      "plugin:@typescript-eslint/recommended",
+      "plugin:react-hooks/recommended"
     ],
     "rules": {
+      "react-hooks/exhaustive-deps": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {


### PR DESCRIPTION
Linting React hooks with `eslint-plugin-react-hooks`. In addition to bringing in the new eslint plugin, this PR also:

- Addresses `react-hooks/rules-of-hooks` errors by updating the `useWidgetUrl` hook to no longer conditionally call other hooks and instead do all of the branching logic inside of a larger effect hook.
- Disables `react-hooks/exhaustive-deps` rule.