### PR TITLE
Conditionally use removeEventListener which has been deprecated

### DIFF
--- a/src/platform/deeplink.ts
+++ b/src/platform/deeplink.ts
@@ -15,8 +15,13 @@ export const onUrlChange = (fn: (event: UrlChangeEvent) => void, dispatchBufferS
     }
   }
 
-  Linking.addEventListener("url", callback)
+  const sub = Linking.addEventListener("url", callback)
 
+  /* removeEventListener is deprecated but addEventListener does not return a
+   * subscription object in versions of React Native v0.64 or below. We can
+   * remove this condition when v64 (or below) is no longer supported.
+   */
   return () =>
-    Linking.removeEventListener("url", callback)
+    sub ? sub.remove() :
+      Linking.removeEventListener("url", callback)
 }

--- a/src/platform/screen.ts
+++ b/src/platform/screen.ts
@@ -24,8 +24,13 @@ export const onDimensionChange = (fn: (orientation: Orientation) => void) => {
   const callback = () =>
     fn(isPortrait() ? Orientation.Portrait : Orientation.Landscape)
 
-  Dimensions.addEventListener("change", callback)
+  const sub = Dimensions.addEventListener("change", callback)
 
+  /* removeEventListener is deprecated but addEventListener does not return a
+   * subscription object in versions of React Native v0.64 or below. We can
+   * remove this condition when v64 (or below) is no longer supported.
+   */
   return () =>
-    Dimensions.removeEventListener("change", callback)
+    sub ? sub.remove() :
+      Dimensions.removeEventListener("change", callback)
 }


### PR DESCRIPTION
`removeEventListener` is deprecated but `addEventListener` does not return a subscription object in versions of React Native v0.64 or below. This conditionally calls `remove` on the subscription when we get it back, and uses `removeEventListener` otherwise. This will work in all supported version of React Native. We can remove this condition when v64 (or below) is no longer supported.

No functionality is changing and these warning will go away once this is merged:

```
WARN  EventEmitter.removeListener('change', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.
WARN  EventEmitter.removeListener('url', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.
```