### PR TITLE
Limiting usage of WidgetLoadUrlCallbackProps

### DIFF
--- a/src/components/PulseWidgets.tsx
+++ b/src/components/PulseWidgets.tsx
@@ -1,6 +1,6 @@
 import { dispatchPulseLocationChangeEvent, PulsePostMessageCallbackProps } from "@mxenabled/widget-post-message-definitions"
 
-import { WidgetLoadingProps, WidgetStylingProps, WidgetLoadUrlCallbackProps } from "./standard_props"
+import { WidgetLoadingProps, WidgetStylingProps } from "./standard_props"
 import { Type, WidgetOptionProps, widgetOptionsFromProps } from "../widget/configuration"
 
 import { useWidgetRenderer } from "./renderer"
@@ -8,7 +8,6 @@ import { useWidgetRenderer } from "./renderer"
 export type PulseWidgetProps =
   & WidgetLoadingProps
   & WidgetStylingProps
-  & WidgetLoadUrlCallbackProps
   & WidgetOptionProps
   & PulsePostMessageCallbackProps
 

--- a/src/components/make_component.tsx
+++ b/src/components/make_component.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react"
 import { dispatchWidgetLocationChangeEvent, WidgetPostMessageCallbackProps } from "@mxenabled/widget-post-message-definitions"
 
-import { WidgetLoadingProps, WidgetStylingProps, WidgetLoadUrlCallbackProps } from "./standard_props"
+import { WidgetLoadingProps, WidgetStylingProps } from "./standard_props"
 import { Type, WidgetOptionProps, widgetOptionsFromProps as optsFromProps } from "../widget/configuration"
 
 import { useWidgetRenderer } from "./renderer"
@@ -9,7 +9,6 @@ import { useWidgetRenderer } from "./renderer"
 type Props =
   & WidgetLoadingProps
   & WidgetStylingProps
-  & WidgetLoadUrlCallbackProps
   & WidgetOptionProps
   & WidgetPostMessageCallbackProps
 


### PR DESCRIPTION
`WidgetLoadUrlCallbackProps` is only needed for components that work with OAuth. This removes the `onLoadUrl` and `onLoadUrlError` props from all components except the Connect-related ones.