### PR TITLE
Removing superfluous ConnectAggregationWidget component

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ This SDK exposes the following components:
 
 - `AccountsWidget`
 - `BudgetsWidget`
-- `ConnectAggregationWidget`
 - `ConnectVerificationWidget`
 - `ConnectWidget`
 - `ConnectionsWidget`

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import { View } from "react-native"
 
-import { ConnectAggregationWidget } from "@mxenabled/react-native-widget-sdk"
+import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 import config from "./config.json"
 
 export default function App() {
   return (
     <View style={{ flex: 1 }}>
-      <ConnectAggregationWidget
+      <ConnectWidget
         {...config}
 
         onSsoUrlLoadError={(error) => {

--- a/src/components/ConnectWidgets.tsx
+++ b/src/components/ConnectWidgets.tsx
@@ -17,10 +17,6 @@ export type ConnectWidgetProps = SsoUrlProps &
   ConnectPostMessageCallbackProps<string> &
   ConnectWidgetConfigurationProps
 
-export const ConnectAggregationWidget = makeWidgetComponentWithDefaults(ConnectWidget, {
-  mode: "aggregation",
-})
-
 export const ConnectVerificationWidget = makeWidgetComponentWithDefaults(ConnectWidget, {
   mode: "verification",
   includeTransactions: false,


### PR DESCRIPTION
`ConnectAggregationWidget` is not needed since aggregation is the default mode and already used by the `ConnectWidget` component.