### PR TITLE
Updating widget post message definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Documentation for configuration and callback component props.
-- Updating @mxenabled/widget-post-message-definitions to v1.0.8.
+- Updating @mxenabled/widget-post-message-definitions to v1.0.9.
 - Loading additional widgets in example application.
 
 ## [1.0.5] - 2022-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Documentation for configuration and callback component props.
-- Updating @mxenabled/widget-post-message-definitions to v1.0.6.
+- Updating @mxenabled/widget-post-message-definitions to v1.0.8.
 - Loading additional widgets in example application.
 
 ## [1.0.5] - 2022-03-09

--- a/docs/widget_callback_props.md
+++ b/docs/widget_callback_props.md
@@ -288,6 +288,7 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 - Payload fields:
     - `user_guid` (`string`)
     - `session_guid` (`string`)
+    - `member_guid` (optional) (`string`)
 
 <details>
 <summary>Click here to view a sample usage of <code>onOAuthError</code>.</summary>
@@ -301,6 +302,7 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
   onOAuthError={(payload) => {
     console.log(`User guid: ${payload.user_guid}`)
     console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Member guid: ${payload.member_guid}`)
   }
 />
 ```

--- a/docs/widget_callback_props.md
+++ b/docs/widget_callback_props.md
@@ -288,7 +288,6 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 - Payload fields:
     - `user_guid` (`string`)
     - `session_guid` (`string`)
-    - `member_guid` (`string`)
 
 <details>
 <summary>Click here to view a sample usage of <code>onOAuthError</code>.</summary>
@@ -302,7 +301,6 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
   onOAuthError={(payload) => {
     console.log(`User guid: ${payload.user_guid}`)
     console.log(`Session guid: ${payload.session_guid}`)
-    console.log(`Member guid: ${payload.member_guid}`)
   }
 />
 ```
@@ -352,6 +350,10 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 
 ---
 ### Step change (`mx/connect/stepChange`)
+
+**Warning**: This message is intended for analytics tracking purposes and not
+controlling or altering user experience. The contents of this
+message's payload is subject to change.
 
 - Widget callback prop name: `onStepChange`
 - Payload fields:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2920,9 +2920,9 @@
       }
     },
     "node_modules/@mxenabled/widget-post-message-definitions": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.6.tgz",
-      "integrity": "sha512-sMIBDdK45/N2B81Hr2zsfcffaaOIMZRiBN3qdfEg/1bNRZe4JTs9DSHDPetDgsMCpvQPr7sJLApFahb7yekBwg=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.8.tgz",
+      "integrity": "sha512-9wv3y7Mo64vhYnCaoMS5i/TljUZy18b+Hm67eSWdMkYcugRnjZLSYBQmkQU+aCENBpRvCD8MblpO+upSj7l6VA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -18217,9 +18217,9 @@
       }
     },
     "@mxenabled/widget-post-message-definitions": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.6.tgz",
-      "integrity": "sha512-sMIBDdK45/N2B81Hr2zsfcffaaOIMZRiBN3qdfEg/1bNRZe4JTs9DSHDPetDgsMCpvQPr7sJLApFahb7yekBwg=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.8.tgz",
+      "integrity": "sha512-9wv3y7Mo64vhYnCaoMS5i/TljUZy18b+Hm67eSWdMkYcugRnjZLSYBQmkQU+aCENBpRvCD8MblpO+upSj7l6VA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2920,9 +2920,9 @@
       }
     },
     "node_modules/@mxenabled/widget-post-message-definitions": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.8.tgz",
-      "integrity": "sha512-9wv3y7Mo64vhYnCaoMS5i/TljUZy18b+Hm67eSWdMkYcugRnjZLSYBQmkQU+aCENBpRvCD8MblpO+upSj7l6VA=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.9.tgz",
+      "integrity": "sha512-N5lMcq6VzoVPsTSP4cFDTzzWSPtR4vqCzccRrseYf+EI8391RxazlyL9SzNmcyrOa9UBJqliRlctRXilf3Pyyg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -18217,9 +18217,9 @@
       }
     },
     "@mxenabled/widget-post-message-definitions": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.8.tgz",
-      "integrity": "sha512-9wv3y7Mo64vhYnCaoMS5i/TljUZy18b+Hm67eSWdMkYcugRnjZLSYBQmkQU+aCENBpRvCD8MblpO+upSj7l6VA=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mxenabled/widget-post-message-definitions/-/widget-post-message-definitions-1.0.9.tgz",
+      "integrity": "sha512-N5lMcq6VzoVPsTSP4cFDTzzWSPtR4vqCzccRrseYf+EI8391RxazlyL9SzNmcyrOa9UBJqliRlctRXilf3Pyyg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "prepack": "npm run build",
-    "clean": "[ -d dist ] && rm -r dist",
+    "clean": "[ -d dist ] && rm -r dist || true",
     "compile": "tsc --declaration --noEmit false --outDir dist",
     "build": "npm run clean && npm run compile && npm run documentation",
     "documentation": "cp node_modules/@mxenabled/widget-post-message-definitions/docs/react-native-sdk-generated.md docs/widget_callback_props.md",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "url": "https://github.com/mxenabled/react-native-widget-sdk.git"
   },
   "scripts": {
-    "prepack": "npm run build:dist",
-    "documentation:copy": "cp node_modules/@mxenabled/widget-post-message-definitions/docs/generated.md docs/widget_callback_props.md",
-    "build": "tsc",
-    "build:dist": "[ -d dist ] && rm -r dist; npm run build -- --declaration --noEmit false --outDir dist",
+    "prepack": "npm run build",
+    "clean": "[ -d dist ] && rm -r dist",
+    "compile": "tsc --declaration --noEmit false --outDir dist",
+    "build": "npm run clean && npm run compile && npm run documentation",
+    "documentation": "cp node_modules/@mxenabled/widget-post-message-definitions/docs/react-native-sdk-generated.md docs/widget_callback_props.md",
     "format": "npm run prettier -- -w",
     "prettier": "prettier src test example/App.tsx",
     "lint": "eslint src test",


### PR DESCRIPTION
Updating widget post message definitions package and doing a little bit of refactoring in npm scripts so that the `npm run documentation` (which copies the docs from the message definitions package) run as part of the build.