### PR TITLE
Deeplinking: listening for URL events with expo-linking for Expo applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,30 @@ your application, you will need to do three things:
   scheme](https://www.npmjs.com/package/uri-scheme) package to manage your
   application's schemes.
 - Provide your application's scheme to the widget component with the
-  `uiMessageWebviewUrlScheme` prop.
+  `uiMessageWebviewUrlScheme` prop. Expo users should use `clientRedirectUrl`
+  instead, see note below.
 
 ```jsx
 <ConnectWidget uiMessageWebviewUrlScheme="sampleScheme" />
+```
+
+**Note for Expo users:** Expo applications are not installed with a unique
+application scheme unless it is installed as standalone application. If this is
+the case for you, then you will need to use the `clientRedirectUrl` prop
+instead of `uiMessageWebviewUrlScheme`.
+
+`clientRedirectUrl` works similarly to `uiMessageWebviewUrlScheme`, except you
+will need to pass in the full URL to your Expo application and include
+`/oauth_complete` at the end of the URL path in order for the Widget SDK to
+properly detect the linking event. Below you will find examples of what
+redirect URLs will look like.
+
+- When running locally, `exp://127.0.0.1:19000/--/oauth_complete`.
+- In development, `exp://wg-qka.community.app.exp.direct:80/--/oauth_complete`.
+- In production, `exp://exp.host/@community/with-webbrowser-redirect`.
+
+```
+<ConnectWidget clientRedirectUrl="exp://127.0.0.1:19000/--/oauth_complete" />
 ```
 
 ### Available widget components

--- a/README.md
+++ b/README.md
@@ -170,10 +170,12 @@ your application, you will need to do three things:
 <ConnectWidget uiMessageWebviewUrlScheme="sampleScheme" />
 ```
 
-**Note for Expo users:** Expo applications are not installed with a unique
-application scheme unless it is installed as standalone application. If this is
-the case for you, then you will need to use the `clientRedirectUrl` prop
-instead of `uiMessageWebviewUrlScheme`.
+**Note for Expo users:** non-standalone Expo applications are not installed
+with a unique application scheme. If this is the case for you, then you will
+need to use the `clientRedirectUrl` prop instead of
+`uiMessageWebviewUrlScheme`. Note that this does not apply for standalone Expo
+application, if your application is a standalone application you should
+continue to use the `uiMessageWebviewUrlScheme` prop.
 
 `clientRedirectUrl` works similarly to `uiMessageWebviewUrlScheme`, except you
 will need to pass in the full URL to your Expo application and include

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ your application, you will need to do three things:
 ```
 
 **Note for Expo application:** non-standalone Expo applications are not
-installed with a unique application scheme. If this is the case for you, then
-you will need to use the `clientRedirectUrl` prop instead of
-`uiMessageWebviewUrlScheme`. Note that this does not apply for standalone Expo
-application, if your application is a standalone application you should
-continue to use the `uiMessageWebviewUrlScheme` prop.
+installed with a unique application scheme. If you are using a non-standalone
+Expo application, then you will need to use the `clientRedirectUrl` prop
+instead of `uiMessageWebviewUrlScheme`. Note that this does not apply for
+standalone Expo applications, if your application is a standalone application
+then you should continue to use the `uiMessageWebviewUrlScheme` prop.
 
 `clientRedirectUrl` works similarly to `uiMessageWebviewUrlScheme`, except you
 will need to pass in the full URL to your Expo application and include

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ your application, you will need to do three things:
   scheme](https://www.npmjs.com/package/uri-scheme) package to manage your
   application's schemes.
 - Provide your application's scheme to the widget component with the
-  `uiMessageWebviewUrlScheme` prop. Expo application that are not standalone
+  `uiMessageWebviewUrlScheme` prop. Expo applications that are not standalone
   should use `clientRedirectUrl` instead, see note below.
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ your application, you will need to do three things:
 <ConnectWidget uiMessageWebviewUrlScheme="sampleScheme" />
 ```
 
-**Note for Expo application:** non-standalone Expo applications are not
+**Note for Expo applications:** non-standalone Expo applications are not
 installed with a unique application scheme. If you are using a non-standalone
 Expo application, then you will need to use the `clientRedirectUrl` prop
 instead of `uiMessageWebviewUrlScheme`. Note that this does not apply for

--- a/README.md
+++ b/README.md
@@ -163,16 +163,16 @@ your application, you will need to do three things:
   scheme](https://www.npmjs.com/package/uri-scheme) package to manage your
   application's schemes.
 - Provide your application's scheme to the widget component with the
-  `uiMessageWebviewUrlScheme` prop. Expo users should use `clientRedirectUrl`
-  instead, see note below.
+  `uiMessageWebviewUrlScheme` prop. Expo application that are not standalone
+  should use `clientRedirectUrl` instead, see note below.
 
 ```jsx
 <ConnectWidget uiMessageWebviewUrlScheme="sampleScheme" />
 ```
 
-**Note for Expo users:** non-standalone Expo applications are not installed
-with a unique application scheme. If this is the case for you, then you will
-need to use the `clientRedirectUrl` prop instead of
+**Note for Expo application:** non-standalone Expo applications are not
+installed with a unique application scheme. If this is the case for you, then
+you will need to use the `clientRedirectUrl` prop instead of
 `uiMessageWebviewUrlScheme`. Note that this does not apply for standalone Expo
 application, if your application is a standalone application you should
 continue to use the `uiMessageWebviewUrlScheme` prop.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ will need to pass in the full URL to your Expo application and include
 properly detect the linking event. You can use Expo's `Linking.createURL`
 method to create the URL.
 
-```
+```jsx
 <ConnectWidget clientRedirectUrl={Linking.createURL("/oauth_complete")} />
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,16 +163,16 @@ your application, you will need to do three things:
   scheme](https://www.npmjs.com/package/uri-scheme) package to manage your
   application's schemes.
 - Provide your application's scheme to the widget component with the
-  `uiMessageWebviewUrlScheme` prop. Expo applications that are not standalone
-  should use `clientRedirectUrl` instead, see note below.
+  `uiMessageWebviewUrlScheme` prop. Expo applications that are not deployed as
+  standalone applications should use `clientRedirectUrl` instead, see note
+  below.
 
 ```jsx
 <ConnectWidget uiMessageWebviewUrlScheme="sampleScheme" />
 ```
 
-**Note for Expo applications:** non-standalone Expo applications are not
-installed with a unique application scheme. If you are using a non-standalone
-Expo application, then you will need to use the `clientRedirectUrl` prop
+**Note for Expo applications:** since Expo applications rely on Expo's own
+application scheme, Expo users will need to use the `clientRedirectUrl` prop
 instead of `uiMessageWebviewUrlScheme`. Note that this does not apply for
 standalone Expo applications, if your application is a standalone application
 then you should continue to use the `uiMessageWebviewUrlScheme` prop.

--- a/README.md
+++ b/README.md
@@ -178,15 +178,11 @@ instead of `uiMessageWebviewUrlScheme`.
 `clientRedirectUrl` works similarly to `uiMessageWebviewUrlScheme`, except you
 will need to pass in the full URL to your Expo application and include
 `/oauth_complete` at the end of the URL path in order for the Widget SDK to
-properly detect the linking event. Below you will find examples of what
-redirect URLs will look like.
-
-- When running locally, `exp://127.0.0.1:19000/--/oauth_complete`.
-- In development, `exp://wg-qka.community.app.exp.direct:80/--/oauth_complete`.
-- In production, `exp://exp.host/@community/with-webbrowser-redirect`.
+properly detect the linking event. You can use Expo's `Linking.createURL`
+method to create the URL.
 
 ```
-<ConnectWidget clientRedirectUrl="exp://127.0.0.1:19000/--/oauth_complete" />
+<ConnectWidget clientRedirectUrl={Linking.createURL("/oauth_complete")} />
 ```
 
 ### Available widget components

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -11,6 +11,7 @@ words:
   - mxwidgetsdkdemo
   - ngrx
   - tsbuildinfo
+  - webbrowser
 
 ignorePaths:
   - cspell.config.yaml

--- a/src/components/oauth.ts
+++ b/src/components/oauth.ts
@@ -54,7 +54,28 @@ export function useOAuthDeeplink(
   useEffect(() => {
     return onUrlChange(({ url: rawUrl }) => {
       const url = parseUrl(rawUrl, true)
-      if (url.host !== OAuthCompleteHost) {
+
+      /**
+       * When the ui_message_webview_url_scheme setting is used, our backend
+       * will generate a URL which looks like this:
+       *
+       *   <scheme>://<event>?<query>
+       *
+       * For URLs like these, we need to check the host.
+       *
+       * However, when a client is using Expo in dev/qa mode and doesn't have
+       * access to their app's scheme, they rely on the client_redirect_url
+       * setting which must use the host to specify Expo's application
+       * location. In this case, the redirect URL has to have the specified
+       * event as part of the path:
+       *
+       *   exp://<ip>/--/<event>?<query>
+       *
+       * For URLs like these, we need to check the path.
+       */
+      const isOAuthEventUrl =
+        url.host === OAuthCompleteHost || url.pathname?.includes(OAuthCompleteHost)
+      if (!isOAuthEventUrl) {
         return
       }
 

--- a/src/platform/deeplink.ts
+++ b/src/platform/deeplink.ts
@@ -1,4 +1,11 @@
-import { Linking } from "react-native"
+import { Linking as RNLinking } from "react-native"
+
+let Linking: RNLinking
+try {
+  Linking = require("expo-linking")
+} catch (err) {
+  Linking = RNLinking
+}
 
 export type UrlChangeEvent = {
   url: string

--- a/test/components/widgets_test.tsx
+++ b/test/components/widgets_test.tsx
@@ -21,52 +21,81 @@ describe("ConnectWidget", () => {
   fullWidgetComponentTestSuite(ConnectWidget)
 
   describe("OAuth", () => {
-    test("an OAuth deeplink triggers a post message to the web view", async () => {
-      expect.assertions(1)
+    const testCases: {
+      label: string
+      url: string
+      check: (msg: string) => void
+    }[] = [
+      {
+        label:
+          "an OAuth deeplink triggers a post message to the web view (public URL with matching host)",
+        url: "appscheme://oauth_complete?member_guid=MBR-123&status=success",
+        check: (msg) => expect(msg).toContain("MBR-123"),
+      },
+      {
+        label:
+          "an OAuth deeplink triggers a post message to the web view (local URL with matching path)",
+        url: "exp://127.0.0.1:19000/--/oauth_complete?member_guid=MBR-123&status=success",
+        check: (msg) => expect(msg).toContain("MBR-123"),
+      },
+      {
+        label:
+          "an OAuth deeplink triggers a post message to the web view (public URL with matching path)",
+        url: "exp://exp.host/@community/with-webbrowser-redirect/--/oauth_complete?member_guid=MBR-123&status=success",
+        check: (msg) => expect(msg).toContain("MBR-123"),
+      },
+      {
+        label:
+          "an OAuth success deeplink includes the right status (public URL with matching host)",
+        url: "appscheme://oauth_complete?member_guid=MBR-123&status=success",
+        check: (msg) => expect(msg).toContain("oauthComplete/success"),
+      },
+      {
+        label: "an OAuth success deeplink includes the right status (local URL with matching path)",
+        url: "exp://127.0.0.1:19000/--/oauth_complete?member_guid=MBR-123&status=success",
+        check: (msg) => expect(msg).toContain("oauthComplete/success"),
+      },
+      {
+        label:
+          "an OAuth success deeplink includes the right status (public URL with matching path)",
+        url: "exp://exp.host/@community/with-webbrowser-redirect/--/oauth_complete?member_guid=MBR-123&status=success",
+        check: (msg) => expect(msg).toContain("oauthComplete/success"),
+      },
+      {
+        label:
+          "an OAuth failure deeplink includes the right status (public URL with matching host)",
+        url: "appscheme://oauth_complete?member_guid=MBR-123&status=error",
+        check: (msg) => expect(msg).toContain("oauthComplete/error"),
+      },
+      {
+        label: "an OAuth failure deeplink includes the right status (local URL with matching path)",
+        url: "exp://127.0.0.1:19000/--/oauth_complete?member_guid=MBR-123&status=error",
+        check: (msg) => expect(msg).toContain("oauthComplete/error"),
+      },
+      {
+        label:
+          "an OAuth failure deeplink includes the right status (public URL with matching path)",
+        url: "exp://exp.host/@community/with-webbrowser-redirect/--/oauth_complete?member_guid=MBR-123&status=error",
+        check: (msg) => expect(msg).toContain("oauthComplete/error"),
+      },
+    ]
 
-      const component = render(
-        <ConnectWidget
-          url="https://widgets.moneydesktop.com/md/..."
-          sendOAuthPostMessage={(_ref, msg) => {
-            expect(msg).toContain("MBR-123")
-          }}
-        />,
-      )
+    testCases.forEach((testCase) => {
+      test(testCase.label, async () => {
+        expect.assertions(1)
 
-      await waitFor(() => component.findByTestId("widget_webview"))
-      triggerUrlChange("appscheme://oauth_complete?member_guid=MBR-123&status=success")
-    })
+        const component = render(
+          <ConnectWidget
+            url="https://widgets.moneydesktop.com/md/..."
+            sendOAuthPostMessage={(_ref, msg) => {
+              testCase.check(msg)
+            }}
+          />,
+        )
 
-    test("an OAuth success deeplink includes the right status", async () => {
-      expect.assertions(1)
-
-      const component = render(
-        <ConnectWidget
-          url="https://widgets.moneydesktop.com/md/..."
-          sendOAuthPostMessage={(_ref, msg) => {
-            expect(msg).toContain("oauthComplete/success")
-          }}
-        />,
-      )
-
-      await waitFor(() => component.findByTestId("widget_webview"))
-      triggerUrlChange("appscheme://oauth_complete?member_guid=MBR-123&status=success")
-    })
-
-    test("an OAuth failure deeplink includes the right status", async () => {
-      expect.assertions(1)
-
-      const component = render(
-        <ConnectWidget
-          url="https://widgets.moneydesktop.com/md/..."
-          sendOAuthPostMessage={(_ref, msg) => {
-            expect(msg).toContain("oauthComplete/error")
-          }}
-        />,
-      )
-
-      await waitFor(() => component.findByTestId("widget_webview"))
-      triggerUrlChange("appscheme://oauth_complete?member_guid=MBR-123&status=error")
+        await waitFor(() => component.findByTestId("widget_webview"))
+        triggerUrlChange(testCase.url)
+      })
     })
   })
 })


### PR DESCRIPTION
When the `ui_message_webview_url_scheme` setting is used, our backend will generate a URL which looks like this:

    <scheme>://<event>?<query>

For URLs like these, we need to check the host.

However, when a client is using Expo in dev/qa mode and doesn't have access to their app's scheme, they rely on the `client_redirect_url` setting which must use the host to specify Expo's application location. In this case, the redirect URL has to have the specified event as part of the path:

    exp://<ip>/--/<event>?<query>

For URLs like these, we need to check the path.