### PR TITLE
Clarify widget settings being available only when using proxy.

### DIFF
--- a/.github/workflows/package-audit-app.yml
+++ b/.github/workflows/package-audit-app.yml
@@ -1,10 +1,9 @@
-name: Package Audit
+name: Package Audit for example application
 
 on:
   pull_request:
-  push:
-    branches:
-    - master
+    paths:
+    - example
   schedule:
   - cron: "0 0 1 * *" # every month
 
@@ -18,9 +17,6 @@ jobs:
       with:
         node-version: 16
         cache: npm
-
-    - name: Run npm audit (sdk)
-      run: npm audit --omit dev
 
     - name: Run npm audit (app)
       run: npm audit --omit dev

--- a/.github/workflows/package-audit-sdk.yml
+++ b/.github/workflows/package-audit-sdk.yml
@@ -1,0 +1,23 @@
+name: Package Audit for SDK
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+  schedule:
+  - cron: "0 0 1 * *" # every month
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: npm
+
+    - name: Run npm audit
+      run: npm audit --omit dev

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ URL should passed to a Widget component via the `proxy` prop.
 
 ##### Connect Widget configuration
 
-When using the `proxy` option with the Connect Widget, you may pass the widget
-settings directly to the widget component.
+When you are not using the `proxy` setting, you must pass the widget
+configuration in the SSO request that generates the SSO URL. However, when
+using the `proxy` setting with the Connect Widget, those configuration settings
+may be passed directly to the widget component.
 
 - `colorScheme`: Load the widget in the specified colorScheme; options are
   `light` and `dark`. Defaults to `light`.
@@ -104,10 +106,6 @@ settings directly to the widget component.
   disableInstitutionSearch={true}
 />
 ```
-
-Note that if you are not using the `proxy` setting, then all widget
-configuration must be included in the SSO request and passed to the component
-via the SSO URL.
 
 ### Importing the SDK into your project and rendering a widget
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,51 @@ The SDK also has the option of making the SSO request on your behalf to your
 backend service that is able to make requests to our API. If used, the proxy
 URL should passed to a Widget component via the `proxy` prop.
 
+##### Connect Widget configuration
+
+When using the `proxy` option with the Connect Widget, you may pass the widget
+settings directly to the widget component.
+
+- `colorScheme`: Load the widget in the specified colorScheme; options are
+  `light` and `dark`. Defaults to `light`.
+- `currentInstitutionCode`: Load the widget into the credential view for the
+  specified institution.
+- `currentInstitutionGuid`: Load the widget into the credential view for the
+  specified institution.
+- `currentMemberGuid`: Load to a specific member that contains an error or
+  requires MFA from the most recent job. `currentMemberGuid` takes precedence
+  over `currentInstitutionCode`.
+- `disableInstitutionSearch`: When set to true, the institution search feature
+  will be disabled and end users will not be able to navigate to it. Must be
+  used with `currentInstitutionCode`, `currentInstitutionGuid`, or
+  `currentMemberGuid`.
+- `includeTransactions`: When set to false while creating or updating a member,
+  transaction data will not be automatically aggregated. Future manual or
+  background aggregations will not be affected. Defaults to true.
+- `uiMessageWebviewUrlScheme`: Used as the scheme that MX will redirect to at
+  the end of OAuth. This must be a scheme that your application responds to.
+  See [OAuth redirects](#oauth-redirects) for additional information.
+- `updateCredentials`: Loads widget to the update credential view of a current
+  member. Optionally used with `currentMemberGuid`. This option should be used
+  sparingly. The best practice is to use `currentMemberGuid` and let the widget
+  resolve the issue.
+- `waitForFullAggregation`: Loads Connect, but forces the widget to wait until
+  any aggregation-type process is complete in order to fire a member connected
+  postMessage. This allows clients to have transactional data by the time the
+  widget is closed.
+
+```jsx
+<ConnectWidget
+  proxy={"https://server.com/mx-sso-proxy"}
+  colorScheme={"dark"}
+  disableInstitutionSearch={true}
+/>
+```
+
+Note that if you are not using the `proxy` setting, then all widget
+configuration must be included in the SSO request and passed to the component
+via the SSO URL.
+
 ### Importing the SDK into your project and rendering a widget
 
 Once the steps above have been completed, you will be able to import components
@@ -120,36 +165,6 @@ component props:
 - `url`: Widget SSO URL. See [Generating your Widget SSO
   URL](#generating-your-widget-sso-url) for additional information. **This prop
   is required.**
-
-#### Connect specific props
-
-- `colorScheme`: Load the widget in the specified colorScheme; options are
-  `light` and `dark`. Defaults to `light`.
-- `currentInstitutionCode`: Load the widget into the credential view for the
-  specified institution.
-- `currentInstitutionGuid`: Load the widget into the credential view for the
-  specified institution.
-- `currentMemberGuid`: Load to a specific member that contains an error or
-  requires MFA from the most recent job. `currentMemberGuid` takes precedence
-  over `currentInstitutionCode`.
-- `disableInstitutionSearch`: When set to true, the institution search feature
-  will be disabled and end users will not be able to navigate to it. Must be
-  used with `currentInstitutionCode`, `currentInstitutionGuid`, or
-  `currentMemberGuid`.
-- `includeTransactions`: When set to false while creating or updating a member,
-  transaction data will not be automatically aggregated. Future manual or
-  background aggregations will not be affected. Defaults to true.
-- `uiMessageWebviewUrlScheme`: Used as the scheme that MX will redirect to at
-  the end of OAuth. This must be a scheme that your application responds to.
-  See [OAuth redirects](#oauth-redirects) for additional information.
-- `updateCredentials`: Loads widget to the update credential view of a current
-  member. Optionally used with `currentMemberGuid`. This option should be used
-  sparingly. The best practice is to use `currentMemberGuid` and let the widget
-  resolve the issue.
-- `waitForFullAggregation`: Loads Connect, but forces the widget to wait until
-  any aggregation-type process is complete in order to fire a member connected
-  postMessage. This allows clients to have transactional data by the time the
-  widget is closed.
 
 #### OAuth redirects in Connect
 


### PR DESCRIPTION
The Connect Widget's settings are documented in the README, but it was not
clear that they were only applied when using the proxy. This changes that by
moving the documentation for those settings into the proxy section and being
explicitly about them only working when the proxy is in use.