### PR TITLE
Splitting up package audit CI jobs

### DIFF
--- a/.github/workflows/package-audit-app.yml
+++ b/.github/workflows/package-audit-app.yml
@@ -1,10 +1,9 @@
-name: Package Audit
+name: Package Audit for example application
 
 on:
   pull_request:
-  push:
-    branches:
-    - master
+    paths:
+    - example
   schedule:
   - cron: "0 0 1 * *" # every month
 
@@ -18,9 +17,6 @@ jobs:
       with:
         node-version: 16
         cache: npm
-
-    - name: Run npm audit (sdk)
-      run: npm audit --omit dev
 
     - name: Run npm audit (app)
       run: npm audit --omit dev

--- a/.github/workflows/package-audit-sdk.yml
+++ b/.github/workflows/package-audit-sdk.yml
@@ -1,0 +1,23 @@
+name: Package Audit for SDK
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+  schedule:
+  - cron: "0 0 1 * *" # every month
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: npm
+
+    - name: Run npm audit
+      run: npm audit --omit dev


### PR DESCRIPTION
The package audit is failing on the example application, which is blocking some unrelated changes from going out. This changes splits that job into two separate jobs: one for the SDK that continues to be triggered as before (run on every push, PR, on a schedule), and another one for the example application that runs on a schedule and on PRs that make updates to the example application.