### PR TITLE
Troubleshooting post messages documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ widget component but they are not being triggered:
 - Ensure your SSO request is correctly configured for the React Native SDK:
     - `ui_message_version` should be set to `4`.
     - `is_mobile_webview` should be set to `true`.
-- Ensure you are using the appropriate widget component for the `widget_type`
-  used when making the SSO request. For example, if you set `widget_type` to
+- Ensure you are using the corresponding widget component for the `widget_type`
+  used in the SSO request. For example, if you set `widget_type` to
   `connect_widget`, then you should use the `ConnectWidget` component.
 
 ---

--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ widget component but they are not being triggered:
 - Ensure your SSO request is correctly configured for the React Native SDK:
     - `ui_message_version` should be set to `4`.
     - `is_mobile_webview` should be set to `true`.
-- Ensure you the appropriate widget class for the `widget_type` used when
-  making the SSO request. For example, if you set `widget_type` to be
+- Ensure you are using the appropriate widget class for the `widget_type` used
+  when making the SSO request. For example, if you set `widget_type` to be
   `connect_widget`, then you should use the `ConnectWidget` component.
 
 ---

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ This SDK exposes the following components:
 Check the following items if you have passed post message callbacks to your
 widget component but they are not being triggered:
 
-- Ensure your SSO request is correctly configured for the Web SDK:
+- Ensure your SSO request is correctly configured for the React Native SDK:
     - `ui_message_version` should be set to `4`.
     - `is_mobile_webview` should be set to `true`.
 - Ensure you the appropriate widget class for the `widget_type` used when

--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ widget component but they are not being triggered:
 - Ensure your SSO request is correctly configured for the React Native SDK:
     - `ui_message_version` should be set to `4`.
     - `is_mobile_webview` should be set to `true`.
-- Ensure you are using the appropriate widget class for the `widget_type` used
-  when making the SSO request. For example, if you set `widget_type` to be
+- Ensure you are using the appropriate widget component for the `widget_type`
+  used when making the SSO request. For example, if you set `widget_type` to
   `connect_widget`, then you should use the `ConnectWidget` component.
 
 ---

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ This SDK exposes the following components:
 
 #### Post messages not working
 
-Check the following items if you have passed post message callbacks to your
-widget component but they are not being triggered:
+Check the following items if widget post message callbacks are not being
+triggered in your application.
 
 - Ensure your SSO request is correctly configured for the React Native SDK:
     - `ui_message_version` should be set to `4`.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This SDK exposes the following components:
 
 #### Post messages not working
 
-Check the following items if you have passed post message callbacks in your
+Check the following items if you have passed post message callbacks to your
 widget component but they are not being triggered:
 
 - Ensure your SSO request is correctly configured for the Web SDK:

--- a/README.md
+++ b/README.md
@@ -148,20 +148,6 @@ payloads.
 />
 ```
 
-### Troubleshooting
-
-#### Post messages not working
-
-Check the following items if you have passed post message callbacks in your
-widget component but they are not being triggered:
-
-- Ensure your SSO request is correctly configured for the Web SDK:
-    - `ui_message_version` should be set to `4`.
-    - `is_mobile_webview` should be set to `true`.
-- Ensure you the appropriate widget class for the `widget_type` used when
-  making the SSO request. For example, if you set `widget_type` to be
-  `connect_widget`, then you should use the `ConnectWidget` component.
-
 ### Widget props
 
 You can configure the state and behavior of the widget with the following
@@ -237,6 +223,20 @@ This SDK exposes the following components:
 - `SpendingWidget`
 - `TransactionsWidget`
 - `TrendsWidget`
+
+### Troubleshooting
+
+#### Post messages not working
+
+Check the following items if you have passed post message callbacks in your
+widget component but they are not being triggered:
+
+- Ensure your SSO request is correctly configured for the Web SDK:
+    - `ui_message_version` should be set to `4`.
+    - `is_mobile_webview` should be set to `true`.
+- Ensure you the appropriate widget class for the `widget_type` used when
+  making the SSO request. For example, if you set `widget_type` to be
+  `connect_widget`, then you should use the `ConnectWidget` component.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ payloads.
 />
 ```
 
+### Troubleshooting
+
+#### Post messages not working
+
+Check the following items if you have passed post message callbacks in your
+widget component but they are not being triggered:
+
+- Ensure your SSO request is correctly configured for the Web SDK:
+    - `ui_message_version` should be set to `4`.
+    - `is_mobile_webview` should be set to `true`.
+- Ensure you the appropriate widget class for the `widget_type` used when
+  making the SSO request. For example, if you set `widget_type` to be
+  `connect_widget`, then you should use the `ConnectWidget` component.
+
 ### Widget props
 
 You can configure the state and behavior of the widget with the following


### PR DESCRIPTION
Adds a "Troubleshooting" section in our documentation. Right now there's only content for troubleshooting post messages, but ee could have other sections there in the future. For example, we could add an "OAuth redirects not working" section here as well.