### PR TITLE
Removing waitForFullAggregation property

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,6 @@ may be passed directly to the widget component.
   member. Optionally used with `currentMemberGuid`. This option should be used
   sparingly. The best practice is to use `currentMemberGuid` and let the widget
   resolve the issue.
-- `waitForFullAggregation`: Loads Connect, but forces the widget to wait until
-  any aggregation-type process is complete in order to fire a member connected
-  postMessage. This allows clients to have transactional data by the time the
-  widget is closed.
 
 ```jsx
 <ConnectWidget

--- a/src/sso/widget_configuration.ts
+++ b/src/sso/widget_configuration.ts
@@ -73,7 +73,6 @@ export type ConnectWidgetConfiguration = WidgetConfiguration & {
   include_transactions?: boolean
   mode?: ConnectWidgetMode
   update_credentials?: boolean
-  wait_for_full_aggregation?: boolean
 }
 
 export function getWidgetConfigurationFromProps(
@@ -92,7 +91,6 @@ export function getWidgetConfigurationFromProps(
     ui_message_version: 4,
     ui_message_webview_url_scheme: props.uiMessageWebviewUrlScheme,
     update_credentials: props.updateCredentials,
-    wait_for_full_aggregation: props.waitForFullAggregation,
     widget_type: props.widgetType,
   }
 }


### PR DESCRIPTION
This flag is being ignored in the widget so we're removing it from the SDKs.