### PR TITLE
Linking step is allowed to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated setup script to support newer version of React Native that do not
+  implement linking of dependencies.
+
 ## [1.0.8] - 2022-06-10
 ### Fixed
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4,11 +4,18 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
 const { execSync } = require("child_process")
 
+const tryExecSync = (cmd: string) => {
+  try {
+    execSync(cmd)
+  } catch (ignore) {
+  }
+}
+
 try {
   console.log("Installing react-native-webview")
   execSync("npm install --save react-native-webview")
-  console.log("\nLinking react-native-webview")
-  execSync("npx react-native link react-native-webview")
+  console.log("\nLinking react-native-webview (optional for older version of React Native)")
+  tryExecSync("npx react-native link react-native-webview")
   console.log("\nInstalling native dependencies")
   execSync("cd ios && pod install")
   console.log("\nDone, you're now ready to use the MX Widget SDK in your application")

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -7,7 +7,9 @@ const { execSync } = require("child_process")
 const tryExecSync = (cmd: string) => {
   try {
     execSync(cmd)
-  } catch (ignore) {}
+  } catch (ignore) {
+    /* eslint no-empty: "off" */
+  }
 }
 
 try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -7,8 +7,7 @@ const { execSync } = require("child_process")
 const tryExecSync = (cmd: string) => {
   try {
     execSync(cmd)
-  } catch (ignore) {
-  }
+  } catch (ignore) {}
 }
 
 try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -2,24 +2,29 @@
 
 /* istanbul ignore file */
 /* eslint @typescript-eslint/no-var-requires: "off" */
-const { execSync } = require("child_process")
+const { exec, execSync } = require("child_process")
 
-const tryExecSync = (cmd: string) => {
+const tryExec = (cmd: string) => {
+  return new Promise((resolve, _reject) => {
+    exec(cmd).on("exit", resolve)
+  })
+}
+
+async function main() {
   try {
-    execSync(cmd)
-  } catch (ignore) {
-    /* eslint no-empty: "off" */
+    console.log("1. Installing react-native-webview")
+    execSync("npm install --save react-native-webview")
+
+    console.log("2. Linking react-native-webview (optional for older version of React Native)")
+    await tryExec("npx react-native link react-native-webview")
+
+    console.log("3. Installing native dependencies")
+    execSync("cd ios && pod install")
+
+    console.log("\nDone, you're now ready to use the MX Widget SDK in your application")
+  } catch (error) {
+    console.error(`Error: ${error}`)
   }
 }
 
-try {
-  console.log("Installing react-native-webview")
-  execSync("npm install --save react-native-webview")
-  console.log("\nLinking react-native-webview (optional for older version of React Native)")
-  tryExecSync("npx react-native link react-native-webview")
-  console.log("\nInstalling native dependencies")
-  execSync("cd ios && pod install")
-  console.log("\nDone, you're now ready to use the MX Widget SDK in your application")
-} catch (error) {
-  console.error(`Error: ${error}`)
-}
+main()


### PR DESCRIPTION
Newer versions of React Native do not require or even support manually linking libraries. This command fails on newer versions, so I'm making it so this step can fail when running the setup script. We still want it around for older RN apps.

Also, slightly changing the output:

```
$ npx mx-widget-sdk-setup
1. Installing react-native-webview
2. Linking react-native-webview (optional for older version of React Native)
3. Installing native dependencies

Done, you're now ready to use the MX Widget SDK in your application
```