### PR TITLE
Create test applications CI

### DIFF
--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -33,9 +33,9 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: TestApplication
-        key: ${{ runner.os }}-node-${{ hashFiles('TestApplication/package-lock.json') }}
+        key: ${{ runner.os }}-test-app-node-${{ hashFiles('TestApplication/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-
+          ${{ runner.os }}-test-app-node-
     - uses: actions/cache@v3
       with:
         path: ~/.gradle/caches

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -28,6 +28,13 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('TestRnApp_0_69_1/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('TestRnApp_0_69_1/android/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-caches-
+
 
     - run: npm install
     - run: npm pack
@@ -45,5 +52,5 @@ jobs:
     - name: Upload Android APK
       uses: actions/upload-artifact@v1
       with:
-        name: app-release.apk
+        name: release
         path: TestRnApp_0_69_1/android/app/build/outputs/apk/release/

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 jobs:
-  Setup:
+  Build_Android:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,22 +33,11 @@ jobs:
     - run: npm install
     - run: npm pack
 
-
-  Create_Applications:
-    needs: Setup
-    runs-on: ubuntu-latest
-    steps:
     - name: Create app with React Native v0.69.1
       run: bin/create-test-application 0.69.1
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
 
-
-  Build_Android:
-    needs: Create_Applications
-    runs-on: ubuntu-latest
-
-    steps:
     - name: Build Android Release
       working-directory: TestRnApp_0_69_1/android
       run: ./gradlew assembleRelease

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -34,13 +34,13 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ${{ matrix.app_path }}
-        key: ${{ runner.os }}-node-${{ hashFiles('${{ matrix.app_path }}/package-lock.json') }}
+        key: ${{ runner.os }}-node-${{ hashFiles(matrix.app_path + '/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('${{ matrix.app_path }}/android/gradle/wrapper/gradle-wrapper.properties') }}
+        key: ${{ runner.os }}-gradle-caches-${{ hashFiles(matrix.app_path + '/android/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-caches-
 

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
         INTEGRATION_TEST_APP_NAME: TestApplication
-        NO_RUN: 1
+        INTEGRATION_TEST_NO_RUN_APP: 1
 
     - name: Build Android Release
       working-directory: TestApplication/android

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -1,0 +1,60 @@
+name: Create Test Applications
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+
+jobs:
+  Setup:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: npm
+
+    - uses: actions/cache@v3
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - uses: actions/cache@v3
+      with:
+        path: TestRnApp_0_69_1
+        key: ${{ runner.os }}-node-${{ hashFiles('TestRnApp_0_69_1/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - run: npm install
+    - run: npm pack
+
+
+  Create Applications:
+    needs: Setup
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create app with React Native v0.69.1
+      run: bin/create-test-application 0.69.1
+      env:
+        INTEGRATION_TEST_PROXY: "http://fakeserver.com"
+
+
+  Build Android:
+    needs: Create Applications
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build Android Release
+      working-directory: TestRnApp_0_69_1/android
+      run: ./gradlew assembleRelease
+
+    - name: Upload Android APK
+      uses: actions/upload-artifact@v1
+      with:
+        name: app-release.apk
+        path: TestRnApp_0_69_1/android/app/build/outputs/apk/release/

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -59,6 +59,6 @@ jobs:
     - name: Upload Android APK
       uses: actions/upload-artifact@v1
       with:
-        name: release
+        name: android-release
         path: ${{ matrix.app_path }}/android/app/build/outputs/apk/release/
         retention-days: 7

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -1,7 +1,6 @@
 name: Create Test Applications
 
 on:
-  pull_request:
   push:
     branches:
     - master

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -49,7 +49,6 @@ jobs:
     - name: Create React Native v${{ matrix.version }} application
       run: bin/create-test-application ${{ matrix.version }}
       env:
-        INTEGRATION_TEST_PROXY: "http://fakeserver.com"
         INTEGRATION_TEST_APP_NAME: TestApplication
         INTEGRATION_TEST_NO_RUN_APP: 1
 

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -34,7 +34,7 @@ jobs:
     - run: npm pack
 
 
-  "Create Applications":
+  Create_Applications:
     needs: Setup
     runs-on: ubuntu-latest
     steps:
@@ -44,8 +44,8 @@ jobs:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
 
 
-  Build Android:
-    needs: Create Applications
+  Build_Android:
+    needs: Create_Applications
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -28,7 +28,7 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('TestRnApp_0_69_1/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-caches-${{ hashFiles('TestRnApp_0_69_1/android/gradle/wrapper/gradle-wrapper.properties') }}
@@ -54,3 +54,4 @@ jobs:
       with:
         name: release
         path: TestRnApp_0_69_1/android/app/build/outputs/apk/release/
+        retention-days: 7

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -22,7 +22,6 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-
     - uses: actions/cache@v3
       with:
         path: TestRnApp_0_69_1

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - rn_version: 0.69.1
             app_path: TestRnApp_0_69_1
+          - rn_version: 0.70.1
+            app_path: TestRnApp_0_70_1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -40,18 +40,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-caches-
 
-
     - run: npm install
     - run: npm pack
 
-    - name: Create app with React Native v${{ matrix.rn_version }}
+    - name: Create React Native v${{ matrix.rn_version }} application
       run: bin/create-test-application ${{ matrix.rn_version }}
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
         INTEGRATION_TEST_APP_NAME: TestApplication
         INTEGRATION_TEST_NO_RUN_APP: 1
 
-    - name: Build Android Release
+    - name: Build Android APK
       working-directory: TestApplication/android
       run: ./gradlew assembleRelease
 

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -34,7 +34,7 @@ jobs:
     - run: npm pack
 
 
-  Create Applications:
+  "Create Applications":
     needs: Setup
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -37,6 +37,7 @@ jobs:
       run: bin/create-test-application 0.69.1
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
+        NO_RUN: 1
 
     - name: Build Android Release
       working-directory: TestRnApp_0_69_1/android

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -12,7 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        version: [ 0.69.1, 0.70.1 ]
+        version:
+          - 0.68.1
+          - 0.69.1
+          - 0.70.1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+  schedule:
+  - cron: "0 0 1 * *" # every month
 
 jobs:
   Build_Android:

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -43,8 +43,8 @@ jobs:
     - run: npm install
     - run: npm pack
 
-    - name: Create React Native v${{ matrix.rn_version }} application
-      run: bin/create-test-application ${{ matrix.rn_version }}
+    - name: Create React Native v${{ matrix.version }} application
+      run: bin/create-test-application ${{ matrix.version }}
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
         INTEGRATION_TEST_APP_NAME: TestApplication
@@ -57,6 +57,6 @@ jobs:
     - name: Upload Android APK
       uses: actions/upload-artifact@v3
       with:
-        name: android-release
+        name: android-release-react-native-${{ matrix.version }}
         path: TestApplication/android/app/build/outputs/apk/release/
         retention-days: 7

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -9,6 +9,13 @@ on:
 jobs:
   Build_Android:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - rn_version: 0.69.1
+            app_path: TestRnApp_0_69_1
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -24,14 +31,14 @@ jobs:
           ${{ runner.os }}-node-
     - uses: actions/cache@v3
       with:
-        path: TestRnApp_0_69_1
-        key: ${{ runner.os }}-node-${{ hashFiles('TestRnApp_0_69_1/package-lock.json') }}
+        path: ${{ matrix.app_path }}
+        key: ${{ runner.os }}-node-${{ hashFiles('${{ matrix.app_path }}/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('TestRnApp_0_69_1/android/gradle/wrapper/gradle-wrapper.properties') }}
+        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('${{ matrix.app_path }}/android/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-caches-
 
@@ -39,19 +46,19 @@ jobs:
     - run: npm install
     - run: npm pack
 
-    - name: Create app with React Native v0.69.1
-      run: bin/create-test-application 0.69.1
+    - name: Create app with React Native v${{ matrix.rn_version }}
+      run: bin/create-test-application ${{ matrix.rn_version }}
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
         NO_RUN: 1
 
     - name: Build Android Release
-      working-directory: TestRnApp_0_69_1/android
+      working-directory: ${{ matrix.app_path }}/android
       run: ./gradlew assembleRelease
 
     - name: Upload Android APK
       uses: actions/upload-artifact@v1
       with:
         name: release
-        path: TestRnApp_0_69_1/android/app/build/outputs/apk/release/
+        path: ${{ matrix.app_path }}/android/app/build/outputs/apk/release/
         retention-days: 7

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -56,7 +56,7 @@ jobs:
       run: ./gradlew assembleRelease
 
     - name: Upload Android APK
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: android-release
         path: TestApplication/android/app/build/outputs/apk/release/

--- a/.github/workflows/create-test-applications.yml
+++ b/.github/workflows/create-test-applications.yml
@@ -12,11 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - rn_version: 0.69.1
-            app_path: TestRnApp_0_69_1
-          - rn_version: 0.70.1
-            app_path: TestRnApp_0_70_1
+        version: [ 0.69.1, 0.70.1 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -33,14 +29,14 @@ jobs:
           ${{ runner.os }}-node-
     - uses: actions/cache@v3
       with:
-        path: ${{ matrix.app_path }}
-        key: ${{ runner.os }}-node-${{ hashFiles(matrix.app_path + '/package-lock.json') }}
+        path: TestApplication
+        key: ${{ runner.os }}-node-${{ hashFiles('TestApplication/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-caches-${{ hashFiles(matrix.app_path + '/android/gradle/wrapper/gradle-wrapper.properties') }}
+        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('TestApplication/android/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-caches-
 
@@ -52,15 +48,16 @@ jobs:
       run: bin/create-test-application ${{ matrix.rn_version }}
       env:
         INTEGRATION_TEST_PROXY: "http://fakeserver.com"
+        INTEGRATION_TEST_APP_NAME: TestApplication
         NO_RUN: 1
 
     - name: Build Android Release
-      working-directory: ${{ matrix.app_path }}/android
+      working-directory: TestApplication/android
       run: ./gradlew assembleRelease
 
     - name: Upload Android APK
       uses: actions/upload-artifact@v1
       with:
         name: android-release
-        path: ${{ matrix.app_path }}/android/app/build/outputs/apk/release/
+        path: TestApplication/android/app/build/outputs/apk/release/
         retention-days: 7

--- a/bin/create-test-application
+++ b/bin/create-test-application
@@ -24,7 +24,7 @@ main() {
   install_sdk_in_app 3
   setup_sdk_in_app 4
   save_app_code 5
-  run_in_ios 6
+  [ -z "$NO_RUN" ] && run_in_ios 6
 }
 
 print_usage() {

--- a/bin/create-test-application
+++ b/bin/create-test-application
@@ -19,12 +19,16 @@ main() {
   fi
 
   print_info
+
   build_sdk_package 1
   create_app 2
   install_sdk_in_app 3
   setup_sdk_in_app 4
   save_app_code 5
-  [ -z "$NO_RUN" ] && run_in_ios 6
+
+  if [ -z "$NO_RUN" ]; then
+    run_in_ios 6
+  fi
 }
 
 print_usage() {

--- a/bin/create-test-application
+++ b/bin/create-test-application
@@ -43,6 +43,11 @@ print_usage() {
   echo "      - or -"
   echo
   echo "    - INTEGRATION_TEST_PROXY"
+  echo
+  echo
+  echo "  The following environment variables are required:"
+  echo "    - INTEGRATION_TEST_APP_NAME"
+  echo "    - INTEGRATION_TEST_NO_RUN_APP"
 }
 
 print_info() {

--- a/bin/create-test-application
+++ b/bin/create-test-application
@@ -26,7 +26,7 @@ main() {
   setup_sdk_in_app 4
   save_app_code 5
 
-  if [ -z "$NO_RUN" ]; then
+  if [ -z "$INTEGRATION_TEST_NO_RUN_APP" ]; then
     run_in_ios 6
   fi
 }

--- a/bin/create-test-application
+++ b/bin/create-test-application
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 rn_version=${1:-latest}
-app_name="TestRnApp_$(echo "$rn_version" | tr "." "_")"
+app_name="${INTEGRATION_TEST_APP_NAME:-TestRnApp_$(echo "$rn_version" | tr "." "_")}"
 sdk_version=$(node -e 'console.log(require("./package.json").version)')
 sdk_tar="mxenabled-react-native-widget-sdk-${sdk_version}.tgz"
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -6,6 +6,7 @@ words:
   - deeplink
   - deeplinking
   - finstrong
+  - gradlew
   - mxenabled
   - mxmobilewidgetsdkdemo
   - mxwidgetsdkdemo


### PR DESCRIPTION
Creates test applications for various versions of React Native (latest three versions: 0.70.1, 0.69.1, and 0.68.1). These apps are meant to be downloaded and tested manually in a device/simulator, or perhaps event automatically tested in the future. The benefit is that the apps are built automatically, which (1) let's us make sure we're able to build an app that uses our SDK, and (2) speeds up the process of testing the SDK on multiple releases of React Native since the building is all done concurrently on the CI servers.

Go to [this page](https://github.com/mxenabled/react-native-widget-sdk/actions/workflows/create-test-applications.yml) to see past jobs. Then go to a [job's summary](https://github.com/mxenabled/react-native-widget-sdk/actions/runs/3074799646) to see the artifacts. These artifacts include the APKs. Android APKs can be installed in a simulator by dragging and dropping the `.apk` file on a running simulator. For now, this is only building an Android APK. iOS apps will come in the future.