### PR TITLE
CT-127 startLoadWithResult error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Giving you as few steps as possible to get up and running with an MX React
 Native widget. Please refer to our [React Native Widget SDK
 documentation][sdk_docs] to get started.
 
-[sdk_docs]: https://docs.mx.com/connect/guides/sdk#react_native "React Native Widget SDK"
+[sdk_docs]: https://docs.mx.com/connect/guides/widget-sdks/react-native/getting-started/ "React Native Widget SDK"

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Giving you as few steps as possible to get up and running with an MX React
 Native widget. Please refer to our [React Native Widget SDK
 documentation][sdk_docs] to get started.
 
-[sdk_docs]: https://docs.mx.com/connect/guides/widget-sdks/react-native/getting-started/ "React Native Widget SDK"
+[sdk_docs]: https://docs.mx.com/connect/guides/sdk#react_native "React Native Widget SDK"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@mxenabled/react-native-widget-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxenabled/react-native-widget-sdk",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@mxenabled/widget-post-message-definitions": "^1.0.0",
         "react-native-base64": "^0.2.1",
-        "react-native-webview": "^11.15.0",
+        "react-native-webview": "^13.6.2",
         "url": "^0.11.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mxenabled/react-native-widget-sdk",
   "description": "MX React Native Widget SDK",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/src/index.js",
   "source": "src/index.ts",
   "license": "MIT",
@@ -37,7 +37,7 @@
   "dependencies": {
     "@mxenabled/widget-post-message-definitions": "^1.0.0",
     "react-native-base64": "^0.2.1",
-    "react-native-webview": "^11.15.0",
+    "react-native-webview": "^13.6.2",
     "url": "^0.11.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
With the latest iOS update, Apple has started throwing `startLoadWithResult` errors. Upgrading to the latest version of the WebView fixes the errors.

See: https://github.com/react-native-webview/react-native-webview/issues/124

MX issue: https://mxcom.atlassian.net/browse/CT-127